### PR TITLE
feat: restrict AWS IAM permissions

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -11,8 +11,8 @@ locals {
     "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonS3TablesFullAccess",
   ]
 
-  # Conditionally include IAMFullAccess based on scoped_iam_permissions variable
-  managed_policies = var.scoped_iam_permissions ? local.base_managed_policies : concat(
+  # Conditionally include IAMFullAccess based on restricted_iam_permissions variable
+  managed_policies = var.restricted_iam_permissions ? local.base_managed_policies : concat(
     ["arn:${data.aws_partition.current.partition}:iam::aws:policy/IAMFullAccess"],
     local.base_managed_policies
   )
@@ -81,7 +81,7 @@ resource "aws_iam_role_policy" "this" {
         Action   = "vpce:AllowMultiRegion",
         Resource = "*"
       }
-    ], var.scoped_iam_permissions ? [
+    ], var.restricted_iam_permissions ? [
       {
         Sid    = "IAMUserManagement"
         Effect = "Allow"

--- a/variables.tf
+++ b/variables.tf
@@ -150,7 +150,7 @@ variable "require_imdsv2" {
   default     = false
 }
 
-variable "scoped_iam_permissions" {
+variable "restricted_iam_permissions" {
   type        = bool
   description = "Use scoped IAM permissions instead of IAMFullAccess. When true, IAM user operations are limited to *-clickhouse-backup users only."
   default     = false

--- a/variables.tf
+++ b/variables.tf
@@ -149,3 +149,9 @@ variable "require_imdsv2" {
   description = "[EXPERIMENTAL] Whether to require IMDSv2 (Instance Metadata Service version 2) for EC2 instances."
   default     = false
 }
+
+variable "scoped_iam_permissions" {
+  type        = bool
+  description = "Use scoped IAM permissions instead of IAMFullAccess. When true, IAM user operations are limited to *-clickhouse-backup users only."
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -155,3 +155,9 @@ variable "restricted_iam_permissions" {
   description = "Use scoped IAM permissions instead of IAMFullAccess. When true, IAM user operations are limited to *-clickhouse-backup users only."
   default     = false
 }
+
+variable "create_user_permissions" {
+  type        = bool
+  description = "Create user permissions for the IAM role."
+  default     = true
+}


### PR DESCRIPTION
I tested this set of permission provisioning and de-provisioning a cluster.

I opted for adding this feature under a feature flag to avoid unexpected issues in other envs