### PR TITLE
fix: harden user-data bootstrap script

### DIFF
--- a/user-data.sh.tpl
+++ b/user-data.sh.tpl
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+exec > >(tee /var/log/user-data.log) 2>&1
 
 yum update -y && yum -y install docker && systemctl enable --now docker && usermod -a -G docker ec2-user
 
@@ -21,6 +22,7 @@ trap on_exit EXIT
 mkdir -p /etc/altinitycloud
 
 aws ssm get-parameter --name "${ssm_parameter_name}" --with-decryption --query "Parameter.Value" --output text > /etc/altinitycloud/cloud-connect.pem
+chmod 600 /etc/altinitycloud/cloud-connect.pem
 
 %{ if ca_crt != "" }
 echo "${ca_crt}" > /etc/altinitycloud/ca.pem
@@ -31,6 +33,17 @@ docker run -d --name=altinitycloud-connect --restart=always -v /etc/altinityclou
   --url=${url} -i /etc/altinitycloud/cloud-connect.pem %{ if ca_crt != "" } --ca-crt=/etc/altinitycloud/ca.pem %{ endif } \
   --capability aws
 
+# Wait for container to be running
+for i in $(seq 1 10); do
+  if docker inspect --format='{{.State.Running}}' altinitycloud-connect 2>/dev/null | grep -q true; then
+    break
+  fi
+  if [ "$i" -eq 10 ]; then
+    echo "ERROR: cloud-connect container failed to start"
+    exit 1
+  fi
+  sleep 3
+done
 
 aws autoscaling complete-lifecycle-action --lifecycle-action-result CONTINUE --instance-id "$instance" \
   --lifecycle-hook-name ${asg_hook_name} --auto-scaling-group-name ${asg_name}


### PR DESCRIPTION
## Summary
- Add logging via `exec/tee` to `/var/log/user-data.log` for debugging bootstrap failures
- `chmod 600` on PEM file immediately after download
- Verify cloud-connect container is running (up to 30s) before completing lifecycle hook

## Test plan
- [ ] Deploy new instance and verify `/var/log/user-data.log` is populated
- [ ] Verify PEM file permissions are `600`
- [ ] Simulate container crash during bootstrap and confirm lifecycle hook returns ABANDON