### PR TITLE
feat: optionally manage AWS Service-Linked Roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- New `create_service_linked_roles` (bool, default `false`) and `service_linked_roles` (set, default `["eks", "eks-nodegroup", "elb"]`) variables to optionally let the module create the AWS Service-Linked Roles required by EKS, EKS Nodegroups and ELB. Centralises the SLR identifiers in `service_linked_roles.tf` so the permissions boundary statement and the resources stay in sync. Closes [#18](https://github.com/Altinity/terraform-altinitycloud-connect-aws/issues/18).
+
+### Fixed
+- Permissions boundary `ServiceLinkedRoles` statement now also covers `eks.amazonaws.com` (`AWSServiceRoleForAmazonEKS`), preventing `iam:CreateServiceLinkedRole` failures on first EKS cluster creation.
+
 ## [0.3.2](https://github.com/Altinity/terraform-altinitycloud-connect-aws/compare/v0.3.1...v0.3.2)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ module "altinitycloud_connect_aws" {
 | `require_imdsv2` | Require IMDSv2 for EC2 instances | `bool` | `false` |
 | `restricted_iam_permissions` | Use scoped IAM permissions | `bool` | `false` |
 | `create_user_permissions` | Create user permissions for the IAM role | `bool` | `true` |
+| `create_service_linked_roles` | Master switch to let the module create AWS Service-Linked Roles (SLRs). When `false`, `service_linked_roles` is ignored. | `bool` | `false` |
+| `service_linked_roles` | Subset of SLRs to create when `create_service_linked_roles` is `true`. Accepts any of `["eks", "eks-nodegroup", "elb"]`. SLRs are global per account; drop the ones you already have. | `set(string)` | `["eks", "eks-nodegroup", "elb"]` |
 
 For a complete list of variables, see [variables.tf](variables.tf).
 
@@ -176,16 +178,67 @@ For a complete list of variables, see [variables.tf](variables.tf).
 
 ## Troubleshooting
 
-- **Instance fails to start:** Check certificate validity and network connectivity to Altinity.Cloud. Review CloudWatch logs.
-- **Permission errors:** Ensure AWS credentials have sufficient permissions and verify IAM role policies.
+### Instance fails to start
 
-### Need Help?
+Check certificate validity and network connectivity to Altinity.Cloud, then review the CloudWatch logs of the cloud-connect EC2 instance(s).
 
-If you encounter issues not covered above, please [create an issue](https://github.com/altinity/terraform-altinitycloud-connect-aws/issues/new) with detailed information about your problem.
+### Permission errors
+
+Ensure the AWS credentials used to apply this module have sufficient permissions and verify the IAM role policies attached to `aws_iam_role.this`.
+
+### Missing AWS Service-Linked Roles
+
+```
+CreateCluster: InvalidParameterException: EKS Cluster Service-Linked Role could not
+be created with cluster role arn:aws:iam::<ACCOUNT>:role/<env>-eks-cluster or cluster
+creator identity. Ensure caller has permission to perform `iam:CreateServiceLinkedRole`
+action
+```
+
+Some AWS services need account-wide Service-Linked Roles (SLRs) that AWS auto-creates the first time the service is used by a sufficiently privileged identity. When `enable_permissions_boundary = true` or `restricted_iam_permissions = true`, that auto-creation can be blocked because the cloud-connect identity is intentionally scoped down. The error above is the most common symptom on EKS, and an analogous one appears on first ELB creation.
+
+You have two ways to fix it:
+
+1. **Pre-create them once** with the AWS CLI (recommended; SLRs are global per account, so this is a one-off):
+
+   ```bash
+   aws iam create-service-linked-role --aws-service-name eks.amazonaws.com
+   aws iam create-service-linked-role --aws-service-name eks-nodegroup.amazonaws.com
+   aws iam create-service-linked-role --aws-service-name elasticloadbalancing.amazonaws.com
+   ```
+
+2. **Let Terraform manage them** by enabling the master switch and (optionally) narrowing the list:
+
+   ```terraform
+   module "altinitycloud_connect_aws" {
+     # ...
+     create_service_linked_roles = true
+     # service_linked_roles defaults to ["eks", "eks-nodegroup", "elb"]
+     # drop the ones already present in your account, e.g.:
+     # service_linked_roles = ["eks", "eks-nodegroup"]
+   }
+   ```
+
+   Existing SLRs will fail with `EntityAlreadyExists` — drop them from `service_linked_roles`, or import them into state:
+
+   ```bash
+   terraform import 'module.altinitycloud_connect_aws.aws_iam_service_linked_role.this["eks"]' \
+     arn:aws:iam::<ACCOUNT>:role/aws-service-role/eks.amazonaws.com/AWSServiceRoleForAmazonEKS
+   ```
+
+For provider-level troubleshooting (environment provisioning status, API tokens, MFA on destroy, immutable attributes), see the [provider README](https://github.com/altinity/terraform-provider-altinitycloud#troubleshooting).
+
+## Support
+
+If you need help, reach out to us via Slack:
+
+- **Enterprise customers**: Use your organization's dedicated Altinity Slack channel.
+- **Community**: Join the [AltinityDB workspace](https://altinitydbworkspace.slack.com/) and post in the **#terraform** channel.
+- **GitHub Issues**: [Open an issue](https://github.com/altinity/terraform-altinitycloud-connect-aws/issues/new) to report bugs or request features.
 
 ## Contributing
 
-Contributions are welcome! Please submit a Pull Request or open an issue for major changes. See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines and advanced configuration examples.
+Contributions are welcome! Please submit a Pull Request or open an issue for major changes. See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines and setup instructions.
 
 ## License
 

--- a/iam_pb.tf
+++ b/iam_pb.tf
@@ -168,16 +168,13 @@ data "aws_iam_policy_document" "permissions-boundary-policy" {
       "iam:CreateServiceLinkedRole",
     ]
     resources = [
-      "arn:aws:iam::${local.account_id}:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup",
-      "arn:aws:iam::${local.account_id}:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing",
+      for k, v in local.service_linked_role_definitions :
+      "arn:aws:iam::${local.account_id}:role/aws-service-role/${v.service_name}/${v.role_name}"
     ]
     condition {
       test     = "StringEqualsIfExists"
       variable = "iam:AWSServiceName"
-      values = [
-        "eks-nodegroup.amazonaws.com",
-        "elasticloadbalancing.amazonaws.com",
-      ]
+      values   = [for k, v in local.service_linked_role_definitions : v.service_name]
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ data "http" "cloud_connect_latest" {
 }
 
 locals {
-  fallback_version      = "0.133.0"
+  fallback_version = "0.133.0"
   cloud_connect_version = coalesce(
     var.cloud_connect_version,
     try(trimprefix(jsondecode(data.http.cloud_connect_latest[0].response_body).tag_name, "v"), ""),

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,7 @@ data "http" "cloud_connect_latest" {
 
 locals {
   fallback_version = "0.133.0"
+
   cloud_connect_version = coalesce(
     var.cloud_connect_version,
     try(trimprefix(jsondecode(data.http.cloud_connect_latest[0].response_body).tag_name, "v"), ""),

--- a/service_linked_roles.tf
+++ b/service_linked_roles.tf
@@ -1,0 +1,29 @@
+locals {
+  # Central definition of every Service-Linked Role this module knows about.
+  # Both the optional aws_iam_service_linked_role resources below and the
+  # "ServiceLinkedRoles" statement in iam_pb.tf derive from this map, so the
+  # SLR identifiers live in a single place.
+  service_linked_role_definitions = {
+    eks = {
+      service_name = "eks.amazonaws.com"
+      role_name    = "AWSServiceRoleForAmazonEKS"
+    }
+    "eks-nodegroup" = {
+      service_name = "eks-nodegroup.amazonaws.com"
+      role_name    = "AWSServiceRoleForAmazonEKSNodegroup"
+    }
+    elb = {
+      service_name = "elasticloadbalancing.amazonaws.com"
+      role_name    = "AWSServiceRoleForElasticLoadBalancing"
+    }
+  }
+}
+
+resource "aws_iam_service_linked_role" "this" {
+  for_each         = var.create_service_linked_roles ? var.service_linked_roles : toset([])
+  aws_service_name = local.service_linked_role_definitions[each.value].service_name
+
+  lifecycle {
+    ignore_changes = [aws_service_name]
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -189,3 +189,40 @@ variable "create_user_permissions" {
   description = "Create user permissions for the IAM role."
   default     = true
 }
+
+variable "create_service_linked_roles" {
+  type        = bool
+  description = <<EOT
+Master switch to let this module manage AWS Service-Linked Roles (SLRs).
+
+When false (default) no SLR is created and the "service_linked_roles" variable is ignored,
+keeping backwards-compatibility for accounts where these roles already exist.
+
+When true, the SLRs listed in "service_linked_roles" are created.
+SLRs are global per AWS account; if any already exists Terraform will fail with
+EntityAlreadyExists. Drop those keys from "service_linked_roles" to skip them.
+EOT
+  default     = false
+}
+
+variable "service_linked_roles" {
+  type        = set(string)
+  description = <<EOT
+Subset of AWS Service-Linked Roles to create when "create_service_linked_roles" is true.
+
+Available keys:
+  - "eks"           -> AWSServiceRoleForAmazonEKS            (eks.amazonaws.com)
+  - "eks-nodegroup" -> AWSServiceRoleForAmazonEKSNodegroup   (eks-nodegroup.amazonaws.com)
+  - "elb"           -> AWSServiceRoleForElasticLoadBalancing (elasticloadbalancing.amazonaws.com)
+
+Check what already exists in your account with:
+  aws iam list-roles --path-prefix /aws-service-role/ --query 'Roles[].RoleName'
+EOT
+  default     = ["eks", "eks-nodegroup", "elb"]
+  validation {
+    condition = alltrue([
+      for r in var.service_linked_roles : contains(["eks", "eks-nodegroup", "elb"], r)
+    ])
+    error_message = "service_linked_roles only accepts: \"eks\", \"eks-nodegroup\", \"elb\"."
+  }
+}


### PR DESCRIPTION
### Summary

- Add `create_service_linked_roles` (bool) and `service_linked_roles` (set) variables to let the module create the EKS, EKS Nodegroup and ELB SLRs, fixing `iam:CreateServiceLinkedRole` failures on accounts using `enable_permissions_boundary` or `restricted_iam_permissions`.
- SLR identifiers are centralised in service_linked_roles.tf and reused by the permissions boundary statement (which now also covers eks.amazonaws.com). README troubleshooting section reorganised to match the provider README. 


> Closes #18.
