### PR TITLE
chore: add CI linting, pre-commit hooks, GitHub templates, and dependabot

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_report.md
+++ b/.github/ISSUE_TEMPLATE/issue_report.md
@@ -1,0 +1,60 @@
+---
+name: Issue report
+about: Report an issue or get help with the module
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the issue**
+A clear and concise description of the issue you're experiencing.
+
+**Environment**
+- Terraform version: [e.g. 1.9.0]
+- Module version: [e.g. 0.3.0]
+- AWS provider version: [e.g. 5.70.0]
+- AWS region: [e.g. us-east-1]
+
+**Error messages**
+Please include any error messages or logs from:
+- Terraform output
+- AWS Console (CloudWatch, EC2, IAM, etc.)
+- `cloud-connect` agent logs
+
+```
+Paste error messages here
+```
+
+**Module configuration**
+Please provide your module configuration (remove any sensitive information):
+
+```hcl
+module "altinitycloud_connect_aws" {
+  source  = "altinity/connect-aws/altinitycloud"
+  version = "~> 0.3.0"
+  # ...
+}
+```
+
+**Terraform plan output**
+If applicable, include the relevant parts of `terraform plan` output (sanitized):
+
+```
+Paste sanitized terraform plan output here
+```
+
+**Steps to reproduce**
+1. Run `terraform init`
+2. Run `terraform apply` with `...`
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here, such as:
+- Network / VPC configuration
+- IAM policies / roles in use
+- AltinityCloud environment status
+- Any custom configurations or modifications

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Affected Components
+* [ ] Module (`*.tf`)
+* [ ] Examples
+* [ ] Docs (`README.md`, `CONTRIBUTING.md`)
+* [ ] CI / Tooling (`.github/`, hooks, lint config)
+* [ ] Other
+
+## Pre-Requisites
+* [ ] `terraform fmt -recursive` was run (or pre-commit hooks executed)
+* [ ] `terraform validate` passes for the root module and examples
+* [ ] `tflint` passes locally
+* [ ] `CHANGELOG.md` updated when user-facing behavior changes
+
+<!-- You can erase any parts of this template not applicable to your Pull Request. -->
+
+## Description
+<!-- Describe the change and the motivation behind it. -->
+
+## Notes for the Reviewer
+<!-- Anything the reviewer should pay extra attention to. -->
+
+> Resolves #[issue-number]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  - package-ecosystem: "terraform"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "terraform"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,88 @@
+name: Lint & Format
+
+on:
+  pull_request:
+    paths-ignore:
+      - "README.md"
+      - "CHANGELOG.md"
+      - "CONTRIBUTING.md"
+  push:
+    branches:
+      - main
+      - master
+    paths-ignore:
+      - "README.md"
+      - "CHANGELOG.md"
+      - "CONTRIBUTING.md"
+
+permissions:
+  contents: read
+
+jobs:
+  fmt:
+    name: terraform fmt
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9.0"
+          terraform_wrapper: false
+
+      - name: Check Terraform formatting
+        run: terraform fmt -check -recursive -diff
+
+  validate:
+    name: terraform validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9.0"
+          terraform_wrapper: false
+
+      - name: Init (root module)
+        run: terraform init -backend=false
+
+      - name: Validate (root module)
+        run: terraform validate -no-color
+
+      - name: Validate examples
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for dir in examples/*/; do
+            echo "::group::validate $dir"
+            (cd "$dir" && terraform init -backend=false && terraform validate -no-color)
+            echo "::endgroup::"
+          done
+
+  tflint:
+    name: tflint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: terraform-linters/setup-tflint@v4
+        with:
+          tflint_version: latest
+
+      - name: Cache TFLint plugins
+        uses: actions/cache@v4
+        with:
+          path: ~/.tflint.d/plugins
+          key: ${{ runner.os }}-tflint-${{ hashFiles('.tflint.hcl') }}
+
+      - name: TFLint init
+        run: tflint --init
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Run TFLint (root module)
+        run: tflint --recursive --config "$(pwd)/.tflint.hcl"

--- a/.github/workflows/update-fallback-version.yml
+++ b/.github/workflows/update-fallback-version.yml
@@ -16,6 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9.0"
+          terraform_wrapper: false
+
       - name: Get latest cloud-connect release
         id: latest
         env:
@@ -33,7 +38,8 @@ jobs:
       - name: Update fallback version
         if: steps.latest.outputs.version != steps.current.outputs.version
         run: |
-          sed -i 's/fallback_version\s*=\s*"[^"]*"/fallback_version      = "${{ steps.latest.outputs.version }}"/' main.tf
+          sed -i 's/fallback_version\s*=\s*"[^"]*"/fallback_version = "${{ steps.latest.outputs.version }}"/' main.tf
+          terraform fmt main.tf
 
       - name: Create Pull Request
         if: steps.latest.outputs.version != steps.current.outputs.version

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+# See https://pre-commit.com for usage and config
+# Install:
+#   pip install pre-commit  # or: brew install pre-commit
+#   pre-commit install
+#   pre-commit install --hook-type commit-msg
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: \.md$
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: check-added-large-files
+        args: ["--maxkb=512"]
+      - id: mixed-line-ending
+        args: ["--fix=lf"]
+
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.96.2
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+        args:
+          - --hook-config=--retry-once-with-cleanup=true
+      - id: terraform_tflint
+        args:
+          - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
+
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.6.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: [feat, fix, chore, docs, refactor, perf, test, build, ci, style, revert, bump]

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,15 @@
+config {
+  call_module_type = "local"
+  force            = false
+}
+
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}
+
+plugin "aws" {
+  enabled = true
+  version = "0.40.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,12 @@ We welcome contributions to this Terraform module! This document provides guidel
 
 1. Fork the repository
 2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Make your changes
-4. Add tests if applicable
-5. Commit your changes (`git commit -m 'Add some amazing feature'`)
-6. Push to the branch (`git push origin feature/amazing-feature`)
-7. Open a Pull Request
+3. Install the development tooling (see [Local Tooling](#local-tooling))
+4. Make your changes
+5. Add tests if applicable
+6. Commit your changes following [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `git commit -m 'feat: add amazing feature'`)
+7. Push to the branch (`git push origin feature/amazing-feature`)
+8. Open a Pull Request
 
 ## Development Guidelines
 
@@ -18,6 +19,44 @@ We welcome contributions to this Terraform module! This document provides guidel
 - Update documentation when adding new features
 - Ensure all examples are working and tested
 - Keep the main README user-focused and move complex examples here
+
+## Local Tooling
+
+This repo ships with a [pre-commit](https://pre-commit.com/) configuration that runs `terraform fmt`, `terraform validate`, [`tflint`](https://github.com/terraform-linters/tflint) and basic file hygiene checks before every commit. It also enforces [Conventional Commits](https://www.conventionalcommits.org/) on the commit message.
+
+### Install
+
+```bash
+# macOS
+brew install pre-commit terraform tflint
+
+# or via pip
+pip install pre-commit
+```
+
+### Enable the hooks
+
+```bash
+pre-commit install                       # runs hooks before each commit
+pre-commit install --hook-type commit-msg # validates commit message format
+```
+
+### Run manually
+
+```bash
+# Run all hooks against every file
+pre-commit run --all-files
+
+# Or just the formatting / linting steps individually
+terraform fmt -recursive
+tflint --init && tflint --recursive
+```
+
+The same checks run on every Pull Request via the [`Lint & Format`](.github/workflows/lint.yml) GitHub Actions workflow.
+
+### Allowed commit prefixes
+
+`feat`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`, `build`, `ci`, `style`, `revert`, `bump`
 
 ## Advanced Configuration Examples
 
@@ -88,9 +127,13 @@ module "altinitycloud_connect_aws" {
 When contributing changes, please ensure:
 
 - All Terraform configurations are valid (`terraform validate`)
+- Code is formatted (`terraform fmt -recursive`)
+- `tflint` passes (`tflint --recursive`)
 - Examples work as expected
 - Documentation is updated accordingly
 - Follow the existing code style and conventions
+
+The recommended way to run all of the above at once is `pre-commit run --all-files`.
 
 ## Questions?
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -9,8 +9,11 @@ resource "altinitycloud_env_certificate" "this" {
 }
 
 module "altinitycloud_connect_aws" {
-  source  = "altinity/connect-aws/altinitycloud"
-  version = "~> 0.3.0"
+  # When using this example outside of this repository, replace the local
+  # `source` with the public Terraform Registry reference:
+  #   source  = "altinity/connect-aws/altinitycloud"
+  #   version = "~> 0.3"
+  source = "../.."
 
   pem = altinitycloud_env_certificate.this.pem
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -9,11 +9,8 @@ resource "altinitycloud_env_certificate" "this" {
 }
 
 module "altinitycloud_connect_aws" {
-  # When using this example outside of this repository, replace the local
-  # `source` with the public Terraform Registry reference:
-  #   source  = "altinity/connect-aws/altinitycloud"
-  #   version = "~> 0.3"
-  source = "../.."
+  source  = "altinity/connect-aws/altinitycloud"
+  version = "~> 0.3"
 
   pem = altinitycloud_env_certificate.this.pem
 }

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0"
     }
+    altinitycloud = {
+      source  = "altinity/altinitycloud"
+      version = ">= 0.5"
+    }
   }
 }

--- a/examples/default-subnets/main.tf
+++ b/examples/default-subnets/main.tf
@@ -9,8 +9,11 @@ resource "altinitycloud_env_certificate" "this" {
 }
 
 module "altinitycloud_connect_aws" {
-  source  = "altinity/connect-aws/altinitycloud"
-  version = "~> 0.3.0"
+  # When using this example outside of this repository, replace the local
+  # `source` with the public Terraform Registry reference:
+  #   source  = "altinity/connect-aws/altinitycloud"
+  #   version = "~> 0.3"
+  source = "../.."
 
   pem                 = altinitycloud_env_certificate.this.pem
   use_default_subnets = true

--- a/examples/default-subnets/main.tf
+++ b/examples/default-subnets/main.tf
@@ -9,11 +9,8 @@ resource "altinitycloud_env_certificate" "this" {
 }
 
 module "altinitycloud_connect_aws" {
-  # When using this example outside of this repository, replace the local
-  # `source` with the public Terraform Registry reference:
-  #   source  = "altinity/connect-aws/altinitycloud"
-  #   version = "~> 0.3"
-  source = "../.."
+  source  = "altinity/connect-aws/altinitycloud"
+  version = "~> 0.3"
 
   pem                 = altinitycloud_env_certificate.this.pem
   use_default_subnets = true

--- a/examples/default-subnets/versions.tf
+++ b/examples/default-subnets/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0"
     }
+    altinitycloud = {
+      source  = "altinity/altinitycloud"
+      version = ">= 0.5"
+    }
   }
 }

--- a/examples/existing-vpc/main.tf
+++ b/examples/existing-vpc/main.tf
@@ -9,11 +9,8 @@ resource "altinitycloud_env_certificate" "this" {
 }
 
 module "altinitycloud_connect_aws" {
-  # When using this example outside of this repository, replace the local
-  # `source` with the public Terraform Registry reference:
-  #   source  = "altinity/connect-aws/altinitycloud"
-  #   version = "~> 0.3"
-  source = "../.."
+  source  = "altinity/connect-aws/altinitycloud"
+  version = "~> 0.3"
 
   pem = altinitycloud_env_certificate.this.pem
 

--- a/examples/existing-vpc/main.tf
+++ b/examples/existing-vpc/main.tf
@@ -9,8 +9,11 @@ resource "altinitycloud_env_certificate" "this" {
 }
 
 module "altinitycloud_connect_aws" {
-  source  = "altinity/connect-aws/altinitycloud"
-  version = "~> 0.3.0"
+  # When using this example outside of this repository, replace the local
+  # `source` with the public Terraform Registry reference:
+  #   source  = "altinity/connect-aws/altinitycloud"
+  #   version = "~> 0.3"
+  source = "../.."
 
   pem = altinitycloud_env_certificate.this.pem
 

--- a/examples/existing-vpc/versions.tf
+++ b/examples/existing-vpc/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0"
     }
+    altinitycloud = {
+      source  = "altinity/altinitycloud"
+      version = ">= 0.5"
+    }
   }
 }

--- a/examples/ha/main.tf
+++ b/examples/ha/main.tf
@@ -9,8 +9,11 @@ resource "altinitycloud_env_certificate" "this" {
 }
 
 module "altinitycloud_connect_aws" {
-  source  = "altinity/connect-aws/altinitycloud"
-  version = "~> 0.3.0"
+  # When using this example outside of this repository, replace the local
+  # `source` with the public Terraform Registry reference:
+  #   source  = "altinity/connect-aws/altinitycloud"
+  #   version = "~> 0.3"
+  source = "../.."
 
   pem           = altinitycloud_env_certificate.this.pem
   replicas      = 3

--- a/examples/ha/main.tf
+++ b/examples/ha/main.tf
@@ -9,11 +9,8 @@ resource "altinitycloud_env_certificate" "this" {
 }
 
 module "altinitycloud_connect_aws" {
-  # When using this example outside of this repository, replace the local
-  # `source` with the public Terraform Registry reference:
-  #   source  = "altinity/connect-aws/altinitycloud"
-  #   version = "~> 0.3"
-  source = "../.."
+  source  = "altinity/connect-aws/altinitycloud"
+  version = "~> 0.3"
 
   pem           = altinitycloud_env_certificate.this.pem
   replicas      = 3

--- a/examples/ha/versions.tf
+++ b/examples/ha/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0"
     }
+    altinitycloud = {
+      source  = "altinity/altinitycloud"
+      version = ">= 0.5"
+    }
   }
 }

--- a/examples/hardened/main.tf
+++ b/examples/hardened/main.tf
@@ -10,11 +10,8 @@ resource "altinitycloud_env_certificate" "this" {
 }
 
 module "altinitycloud_connect_aws" {
-  # When using this example outside of this repository, replace the local
-  # `source` with the public Terraform Registry reference:
-  #   source  = "altinity/connect-aws/altinitycloud"
-  #   version = "~> 0.3"
-  source = "../.."
+  source  = "altinity/connect-aws/altinitycloud"
+  version = "~> 0.3"
 
   pem = altinitycloud_env_certificate.this.pem
 

--- a/examples/hardened/main.tf
+++ b/examples/hardened/main.tf
@@ -10,8 +10,11 @@ resource "altinitycloud_env_certificate" "this" {
 }
 
 module "altinitycloud_connect_aws" {
-  source  = "altinity/connect-aws/altinitycloud"
-  version = "~> 0.3.0"
+  # When using this example outside of this repository, replace the local
+  # `source` with the public Terraform Registry reference:
+  #   source  = "altinity/connect-aws/altinitycloud"
+  #   version = "~> 0.3"
+  source = "../.."
 
   pem = altinitycloud_env_certificate.this.pem
 

--- a/examples/hardened/versions.tf
+++ b/examples/hardened/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0"
     }
+    altinitycloud = {
+      source  = "altinity/altinitycloud"
+      version = ">= 0.5"
+    }
   }
 }

--- a/examples/permissions-boundary/main.tf
+++ b/examples/permissions-boundary/main.tf
@@ -10,11 +10,8 @@ resource "altinitycloud_env_certificate" "this" {
 }
 
 module "altinitycloud_connect_aws" {
-  # When using this example outside of this repository, replace the local
-  # `source` with the public Terraform Registry reference:
-  #   source  = "altinity/connect-aws/altinitycloud"
-  #   version = "~> 0.3"
-  source = "../.."
+  source  = "altinity/connect-aws/altinitycloud"
+  version = "~> 0.3"
 
   pem = altinitycloud_env_certificate.this.pem
 

--- a/examples/permissions-boundary/main.tf
+++ b/examples/permissions-boundary/main.tf
@@ -10,8 +10,11 @@ resource "altinitycloud_env_certificate" "this" {
 }
 
 module "altinitycloud_connect_aws" {
-  source  = "altinity/connect-aws/altinitycloud"
-  version = "~> 0.3.0"
+  # When using this example outside of this repository, replace the local
+  # `source` with the public Terraform Registry reference:
+  #   source  = "altinity/connect-aws/altinitycloud"
+  #   version = "~> 0.3"
+  source = "../.."
 
   pem = altinitycloud_env_certificate.this.pem
 

--- a/examples/permissions-boundary/versions.tf
+++ b/examples/permissions-boundary/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0"
     }
+    altinitycloud = {
+      source  = "altinity/altinitycloud"
+      version = ">= 0.5"
+    }
   }
 }

--- a/examples/ssm-parameter/main.tf
+++ b/examples/ssm-parameter/main.tf
@@ -5,11 +5,8 @@ provider "aws" {
 }
 
 module "altinitycloud_connect_aws" {
-  # When using this example outside of this repository, replace the local
-  # `source` with the public Terraform Registry reference:
-  #   source  = "altinity/connect-aws/altinitycloud"
-  #   version = "~> 0.3"
-  source = "../.."
+  source  = "altinity/connect-aws/altinitycloud"
+  version = "~> 0.3"
 
   pem_ssm_parameter_name = "/altinity/cloud-connect/pem"
 }

--- a/examples/ssm-parameter/main.tf
+++ b/examples/ssm-parameter/main.tf
@@ -5,8 +5,11 @@ provider "aws" {
 }
 
 module "altinitycloud_connect_aws" {
-  source  = "altinity/connect-aws/altinitycloud"
-  version = "~> 0.3.0"
+  # When using this example outside of this repository, replace the local
+  # `source` with the public Terraform Registry reference:
+  #   source  = "altinity/connect-aws/altinitycloud"
+  #   version = "~> 0.3"
+  source = "../.."
 
   pem_ssm_parameter_name = "/altinity/cloud-connect/pem"
 }

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ data "http" "cloud_connect_latest" {
 }
 
 locals {
-  fallback_version      = "0.133.0"
+  fallback_version = "0.133.0"
   cloud_connect_version = coalesce(
     var.cloud_connect_version,
     try(trimprefix(jsondecode(data.http.cloud_connect_latest[0].response_body).tag_name, "v"), ""),

--- a/main.tf
+++ b/main.tf
@@ -171,7 +171,7 @@ resource "aws_autoscaling_group" "this" {
 
   wait_for_capacity_timeout = "7m"
   vpc_zone_identifier = length(var.subnets) > 0 ? var.subnets : (
-    var.use_default_subnets ? data.aws_subnets.default[0].ids : aws_subnet.this.*.id
+    var.use_default_subnets ? data.aws_subnets.default[0].ids : aws_subnet.this[*].id
   )
 
   dynamic "tag" {


### PR DESCRIPTION
## Summary
- Add **Lint & Format** CI workflow (`terraform fmt`, `terraform validate`, `tflint`) on PRs and pushes
- Add **pre-commit** config with terraform hooks (fmt, validate, tflint) and conventional commit enforcement
- Add **tflint** config with AWS ruleset
- Add **GitHub templates** for issues and pull requests
- Add **Dependabot** config for GitHub Actions and Terraform provider updates
- Update **CONTRIBUTING.md** with local tooling setup instructions and conventional commit guidance
- Fix `update-fallback-version` workflow to install Terraform and run `terraform fmt` after `sed`
- Fix `fallback_version` formatting in `main.tf`

## Test plan
- [ ] Verify `Lint & Format` workflow runs on this PR
- [ ] Verify `terraform fmt -check -recursive` passes
- [ ] Verify `terraform validate` passes for root module and examples
- [ ] Verify `tflint` passes
- [ ] Verify PR template renders correctly on new PRs
- [ ] Verify issue template renders correctly on new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)