### PR TITLE
fix: add VPC peering permissions to permissions boundary

### DIFF
--- a/iam_pb.tf
+++ b/iam_pb.tf
@@ -88,6 +88,25 @@ data "aws_iam_policy_document" "permissions-boundary-policy" {
     resources = ["*"]
   }
 
+  # AcceptVpcPeeringConnection does not support aws:RequestTag and the API does
+  # not accept TagSpecifications, so the pcx cannot be tagged before/at accept
+  # time. Scope this permission to peering connections whose accepter VPC lives
+  # in this env's account/region; the env tag is applied immediately after.
+  statement {
+    sid = "AcceptVPCPeering"
+    actions = [
+      "ec2:AcceptVpcPeeringConnection",
+      "ec2:RejectVpcPeeringConnection",
+      "ec2:ModifyVpcPeeringConnectionOptions",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "ArnLike"
+      variable = "ec2:AccepterVpc"
+      values   = ["arn:aws:ec2:${local.region}:${local.account_id}:vpc/*"]
+    }
+  }
+
   statement {
     sid = "EKSAuth"
     actions = [

--- a/iam_pb.tf
+++ b/iam_pb.tf
@@ -88,10 +88,7 @@ data "aws_iam_policy_document" "permissions-boundary-policy" {
     resources = ["*"]
   }
 
-  # AcceptVpcPeeringConnection does not support aws:RequestTag and the API does
-  # not accept TagSpecifications, so the pcx cannot be tagged before/at accept
-  # time. Scope this permission to peering connections whose accepter VPC lives
-  # in this env's account/region; the env tag is applied immediately after.
+  # AcceptVpcPeeringConnection doesn't support RequestTag; scope by accepter VPC instead
   statement {
     sid = "AcceptVPCPeering"
     actions = [


### PR DESCRIPTION
## Summary
- Add `AcceptVpcPeeringConnection`, `RejectVpcPeeringConnection`, and `ModifyVpcPeeringConnectionOptions` to the permissions boundary policy
- `AcceptVpcPeeringConnection` does not support `aws:RequestTag` conditions, so scope is enforced via `ec2:AccepterVpc` ARN condition (account/region)
- Environment tag is applied immediately after accept
